### PR TITLE
fix: remove non-existent docstr-coverage GitHub Action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,14 +118,6 @@ jobs:
       - name: Run pydoclint
         run: uv run pydoclint --style=google src/py_gdelt
 
-      - name: Check docstring coverage with docstr-coverage
-        uses: HunterMcGushion/docstr_coverage@v2.3.2
-        with:
-          fail-under: 90
-          skip-magic: true
-          skip-private: true
-          exclude: tests/**/*
-
   test:
     name: Test (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest


### PR DESCRIPTION
Remove the HunterMcGushion/docstr_coverage action which doesn't exist. Documentation coverage is already comprehensively handled by:
- interrogate: checks coverage percentage with 90% threshold
- pydoclint: validates docstring signatures match function signatures

Both tools run in the doc-coverage CI job and provide sufficient coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)