### PR TITLE
ci(publish): add verbose mode and disable TestPyPI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,7 @@ on:
         required: true
         type: choice
         options:
-          - testpypi
+          # - testpypi  # Disabled for now
           - pypi
 
 jobs:
@@ -40,28 +40,29 @@ jobs:
           name: python-package-distributions
           path: dist/
 
-  publish-to-testpypi:
-    name: Publish to TestPyPI
-    needs: [build]
-    runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_dispatch' && inputs.environment == 'testpypi'
-    environment:
-      name: testpypi
-      url: https://test.pypi.org/p/py-gdelt
-    permissions:
-      id-token: write  # IMPORTANT: mandatory for trusted publishing
-
-    steps:
-      - name: Download distribution artifacts
-        uses: actions/download-artifact@v7
-        with:
-          name: python-package-distributions
-          path: dist/
-
-      - name: Publish to TestPyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          repository-url: https://test.pypi.org/legacy/
+  # publish-to-testpypi:
+  #   name: Publish to TestPyPI
+  #   needs: [build]
+  #   runs-on: ubuntu-latest
+  #   if: github.event_name == 'workflow_dispatch' && inputs.environment == 'testpypi'
+  #   environment:
+  #     name: testpypi
+  #     url: https://test.pypi.org/p/py-gdelt
+  #   permissions:
+  #     id-token: write  # IMPORTANT: mandatory for trusted publishing
+  #
+  #   steps:
+  #     - name: Download distribution artifacts
+  #       uses: actions/download-artifact@v7
+  #       with:
+  #         name: python-package-distributions
+  #         path: dist/
+  #
+  #     - name: Publish to TestPyPI
+  #       uses: pypa/gh-action-pypi-publish@release/v1
+  #       with:
+  #         repository-url: https://test.pypi.org/legacy/
+  #         verbose: true
 
   publish-to-pypi:
     name: Publish to PyPI
@@ -83,6 +84,8 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          verbose: true
 
   create-github-release-notes:
     name: Update GitHub Release Notes


### PR DESCRIPTION
## Summary
- Enable `verbose: true` for PyPI publish action to debug upload errors
- Temporarily disable TestPyPI job and workflow option
- Focus on production PyPI publishing workflow

## Type of Change
- [x] CI/CD improvement

## Testing
- CI workflow syntax validated by GitHub Actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)