### PR TITLE
ci(docs): fix uv pip install for externally managed Python

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,7 +35,7 @@ jobs:
             mkdocs-material-
 
       - name: Install dependencies
-        run: uv pip install --system mkdocs-material mkdocstrings[python]
+        run: uv venv && uv pip install mkdocs-material mkdocstrings[python]
 
       - name: Deploy docs
-        run: mkdocs gh-deploy --force
+        run: uv run mkdocs gh-deploy --force


### PR DESCRIPTION
## Summary
- Fix docs workflow failing with "externally managed" Python error
- Ubuntu runners now enforce PEP 668, blocking `--system` installs
- Switch to `uv venv` + `uv run mkdocs` instead of `--system`

## Type of Change
- [x] Bug fix (CI)

## Testing
- CI will validate the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)