### PR TITLE
docs: add Event, Actor, Mention models to API docs

### DIFF
--- a/docs/api/models.md
+++ b/docs/api/models.md
@@ -2,6 +2,23 @@
 
 Data models represent GDELT records and results.
 
+## Events Models
+
+::: py_gdelt.models.events.Event
+    options:
+      show_root_heading: true
+      heading_level: 3
+
+::: py_gdelt.models.events.Actor
+    options:
+      show_root_heading: true
+      heading_level: 3
+
+::: py_gdelt.models.events.Mention
+    options:
+      show_root_heading: true
+      heading_level: 3
+
 ## Article Models
 
 ::: py_gdelt.models.Article


### PR DESCRIPTION
## Summary
- Add Event, Actor, Mention models to API docs
- Use full path `py_gdelt.models.events.Event` since not exported from `py_gdelt.models`

## Type of Change
- [x] Documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)