### PR TITLE
ci(publish): allow workflow_dispatch to trigger PyPI publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -68,7 +68,7 @@ jobs:
     name: Publish to PyPI
     needs: [build]
     runs-on: ubuntu-latest
-    if: github.event_name == 'release'
+    if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.environment == 'pypi')
     environment:
       name: pypi
       url: https://pypi.org/p/py-gdelt


### PR DESCRIPTION
## Summary
- Fix `publish-to-pypi` job being skipped on manual workflow_dispatch
- Update condition: `release` OR `workflow_dispatch` with `pypi` selected

## Type of Change
- [x] Bug fix (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)