### PR TITLE
fix: rename package to gdelt-py for PyPI and bump to 0.1.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
-name = "py-gdelt"
-version = "0.1.0"
+name = "gdelt-py"
+version = "0.1.1"
 description = "Python client library for GDELT (Global Database of Events, Language, and Tone)"
 readme = "README.md"
 authors = [


### PR DESCRIPTION
## Summary
- Rename distribution name from `py-gdelt` to `gdelt-py` to match PyPI trusted publisher
- Bump version to `0.1.1`

## Notes
- Users will: `pip install gdelt-py`
- Import stays: `import py_gdelt`

## Type of Change
- [x] Bug fix (PyPI publishing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)