### PR TITLE
ci(docs): auto-sync README.md to docs/index.md

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,5 +37,13 @@ jobs:
       - name: Install dependencies
         run: uv venv && uv pip install mkdocs-material mkdocstrings[python]
 
+      - name: Sync README to docs index
+        run: |
+          # Copy README.md to docs/index.md, stripping badge lines
+          echo "<!-- AUTO-GENERATED FROM README.md - DO NOT EDIT DIRECTLY -->" > docs/index.md
+          echo "" >> docs/index.md
+          sed '/^\[!\[/d' README.md >> docs/index.md
+          echo "Synced README.md to docs/index.md"
+
       - name: Deploy docs
         run: uv run mkdocs gh-deploy --force

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,5 @@
+<!-- AUTO-GENERATED FROM README.md - DO NOT EDIT DIRECTLY -->
+
 # gdelt-py
 
 A comprehensive Python client library for the [GDELT](https://www.gdeltproject.org/) (Global Database of Events, Language, and Tone) project.


### PR DESCRIPTION
## Summary
- Add step to docs workflow that syncs README.md to docs/index.md
- Strips badge lines (not needed in docs site)
- Adds auto-generated comment to prevent direct edits

Now you only need to edit README.md - docs will sync automatically on deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)